### PR TITLE
fix for glib e38982df commit

### DIFF
--- a/cpdb/cpdb-frontend.c
+++ b/cpdb/cpdb-frontend.c
@@ -428,7 +428,7 @@ int cpdbSetDefaultPrinter(char *path, cpdb_printer_obj_t *p)
     printers = g_list_prepend(printers, printer_data);
     for (printer = printers; printer != NULL; printer = printer->next)
     {
-        fprintf(fp, "%s\n", printer->data);
+        fprintf(fp, "%s\n", (char *)printer->data);
     }
     g_list_free_full(printers, free);
 

--- a/cpdb/cpdb-frontend.h
+++ b/cpdb/cpdb-frontend.h
@@ -1,6 +1,8 @@
 #ifndef _CPDB_FRONTEND_H_
 #define _CPDB_FRONTEND_H_
 
+#include <glib.h>
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -9,7 +11,6 @@ extern "C"
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <glib.h>
 #include <dirent.h>
 #include <cpdb/cpdb.h>
 

--- a/cpdb/cpdb.h
+++ b/cpdb/cpdb.h
@@ -1,6 +1,8 @@
 #ifndef _CPDB_H_
 #define _CPDB_H_
 
+#include <glib.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -10,7 +12,6 @@ extern "C" {
 #include <unistd.h>
 #include <string.h>
 #include <stdlib.h>
-#include <glib.h>
 #include <sys/types.h>
 #include <pwd.h>
 #include <cpdb/backend-interface.h>


### PR DESCRIPTION
glib headers should no longer be included inside `extern "C" { ... }` blocks. 