### PR TITLE
Add fetch all printer strings translations

### DIFF
--- a/cpdb/cpdb-frontend.h
+++ b/cpdb/cpdb-frontend.h
@@ -31,7 +31,6 @@ extern "C"
 
 typedef struct cpdb_frontend_obj_s cpdb_frontend_obj_t;
 typedef struct cpdb_printer_obj_s cpdb_printer_obj_t;
-typedef struct cpdb_async_obj_s cpdb_async_obj_t;
 typedef struct cpdb_settings_s cpdb_settings_t;
 typedef struct cpdb_options_s cpdb_options_t;
 typedef struct cpdb_option_s cpdb_option_t;
@@ -282,6 +281,10 @@ struct cpdb_printer_obj_s
 
     /**The settings the user selects, and which will be used for printing the job**/
     cpdb_settings_t *settings;
+
+    /** Translations **/
+    char *locale;
+    GHashTable *translations;
 };
 
 /**
@@ -491,6 +494,15 @@ char *cpdbGetChoiceTranslation(cpdb_printer_obj_t *printer_obj, const char *opti
  */
 char *cpdbGetGroupTranslation(cpdb_printer_obj_t *printer_obj, const char *group_name, const char *lang);
 
+
+/**
+ * Get translations for all strings provided by a printer.
+ *
+ * @param printer_obj       Printer object
+ * @param lang              BCP47 language tag to be used for translation
+ */
+void cpdbGetAllTranslations(cpdb_printer_obj_t *printer_obj, const char *lang);
+
 /**
  * Get the cpdb_media_t struct corresponding to a media-size supported by a printer.
  *
@@ -524,13 +536,6 @@ int cpdbGetMediaSize(cpdb_printer_obj_t *printer_obj, const char *media_name, in
  */
 int cpdbGetMediaMargins(cpdb_printer_obj_t *printer_obj, const char *media_name, cpdb_margin_t **margins);
 
-struct cpdb_async_obj_s
-{
-    cpdb_printer_obj_t *p;
-    cpdb_async_callback caller_cb;
-    void *user_data;
-};
-
 /**
  * Asynchronously fetch printer details and options.
  *
@@ -540,6 +545,18 @@ struct cpdb_async_obj_s
  * 
  */
 void cpdbAcquireDetails(cpdb_printer_obj_t *printer_obj, cpdb_async_callback caller_cb, void *user_data);
+
+/**
+ * Asynchronously fetch all printer strings translations,
+ * which can then be obtained using cpdbGet[...]Translation() functions.
+ * For synchronous version, look at cpdbGetAllTranslations().
+ *
+ * @param printer_obj       Printer object
+ * @param lang              BCP47 language tag to be used for translation
+ * @param caller_cb         Callback function
+ * @param user_data         User data to pass to callback functions
+ */
+void cpdbAcquireTranslations(cpdb_printer_obj_t *printer_obj, const char *lang, cpdb_async_callback caller_cb, void *user_data);
 
 /************************************************************************************************/
 /**

--- a/cpdb/cpdb.h
+++ b/cpdb/cpdb.h
@@ -34,6 +34,12 @@ extern "C" {
 #define CPDB_PRINTER_ARRAY_ARGS "a(sssssbss)"
 #define CPDB_PRINTER_ARGS "(sssssbss)"
 
+/* For translations */
+#define CPDB_GRP_PREFIX "GRP"
+#define CPDB_OPT_PREFIX "OPT"
+#define CPDB_TL_DICT_ARGS "a{ss}"
+#define CPDB_TL_ARGS "{ss}"
+
 #define CPDB_PRINTER_ADDED_ARGS "(sssssbss)"
 #define CPDB_JOB_ARGS "(ssssssi)"
 #define CPDB_JOB_ARRAY_ARGS "a(ssssssi)"

--- a/cpdb/interface/org.openprinting.Backend.xml
+++ b/cpdb/interface/org.openprinting.Backend.xml
@@ -54,15 +54,6 @@
             <arg name="locale" direction="in" type="s"/>
             <arg name="translation" direction="out" type="s"/>
         </method>
-        <method name="getHumanReadableOptionName">
-            <arg name="option_name" direction="in" type="s"/>
-            <arg name="human_readable_name" direction="out" type="s"/>
-        </method>
-        <method name="getHumanReadableChoiceName">
-            <arg name="option_name" direction="in" type="s"/>
-            <arg name="choice_name" direction="in" type="s"/>
-            <arg name="human_readable_name" direction="out" type="s"/>
-        </method>
         <method name="isAcceptingJobs">
             <arg name="printer_id" direction="in" type="s"/>
             <arg name="is_accepting" direction="out" type="b"/>
@@ -75,6 +66,11 @@
             <arg name="num_media" direction="out" type="i" />
             <arg name="media" direction="out" type="a(siiia(iiii))" />
             <!-- media contents: media name, width, length, number of supported margins, array of margins (left, right, top, bottom) -->
+        </method>
+        <method name="GetAllTranslations">
+            <arg name="printer_id" direction="in" type="s" />
+            <arg name="locale" direction="in" type="s" />
+            <arg name="translations" direction="out" type="a{ss}" />
         </method>
         <method name="getActiveJobsCount">
             <arg name="printer_id" direction="in" type="s"/>


### PR DESCRIPTION
* Added cpdbGetAllTranslations() to synchronously fetch all printer string translations
* Added cpdbAcquireTranslations() to asychronously fetch them.
* Removed get-human-readable-option/choice-name methods Backend
* Removed cpdb_async_obj_t from cpdb-frontend.h as that is meant for internal use.