### PR TITLE
Removes file system access

### DIFF
--- a/cpdb.pc.in
+++ b/cpdb.pc.in
@@ -3,7 +3,6 @@ exec_prefix=@exec_prefix@
 includedir=@includedir@
 libdir=@libdir@
 datarootdir=@datarootdir@
-cpdb_backend_info_dir=@CPDB_BACKEND_INFO_DIR@
 cpdb_backend_exec_dir=@CPDB_BACKEND_EXEC_DIR@
 
 Cflags: -I${includedir}

--- a/cpdb/cpdb-frontend.h
+++ b/cpdb/cpdb-frontend.h
@@ -193,7 +193,7 @@ void cpdbUnhideTemporaryPrinters(cpdb_frontend_obj_t *frontend_obj);
  * Read the file installed by the backend and create a proxy object
  * on the connection using the backend service name and object path
  */
-PrintBackend *cpdbCreateBackendFromFile(GDBusConnection *, const char *);
+PrintBackend *cpdbCreateBackend(GDBusConnection *, const char *);
 
 /**
  * Find the cpdb_printer_obj_t instance with a particular id and backend name.

--- a/cpdb/cpdb.h
+++ b/cpdb/cpdb.h
@@ -31,6 +31,8 @@ extern "C" {
 #define CPDB_DEBUG_LEVEL   "CPDB_DEBUG_LEVEL"
 #define CPDB_DEBUG_LOGFILE "CPDB_DEBUG_LOGFILE"
 
+#define CPDB_BACKEND_OBJ_PATH "/"
+
 #define CPDB_PRINTER_ARRAY_ARGS "a(sssssbss)"
 #define CPDB_PRINTER_ARGS "(sssssbss)"
 


### PR DESCRIPTION
The frontend should only shout in D-Bus to see which backends are there and to communicate with them. It cannot browse any directory in the host's or backend's file system.