### PR TITLE
text-frontend: Quit on EOF

### DIFF
--- a/tools/cpdb-text-frontend.c
+++ b/tools/cpdb-text-frontend.c
@@ -143,8 +143,8 @@ gpointer control_thread(gpointer user_data)
     {
         printf("> ");
         fflush(stdout);
-        scanf("%1023s", buf);
-        if (strcmp(buf, "stop") == 0)
+        const int ret = scanf("%1023s", buf);
+        if (ret == EOF || strcmp(buf, "stop") == 0)
         {
             g_message("Stopping front end..\n");
 	        return (NULL);


### PR DESCRIPTION
Quit the text frontend when scanf returns EOF,
which e.g. happens when the user presses Ctrl-D.

Previously, pressing Ctrl-D would result in the loop running indefinitely, printing ">" without end.