### PR TITLE
Pass backend name to cpdbRefreshPrinterList as const char*

### DIFF
--- a/cpdb/cpdb-frontend.c
+++ b/cpdb/cpdb-frontend.c
@@ -285,7 +285,7 @@ static void fetchPrinterListFromBackend(cpdb_frontend_obj_t *f, const char *back
     }
 }
 
-bool cpdbRefreshPrinterList(cpdb_frontend_obj_t *f, char *backend) 
+bool cpdbRefreshPrinterList(cpdb_frontend_obj_t *f, const char *backend)
 { 
     int num_printers; 
     GVariantIter iter; 

--- a/cpdb/cpdb-frontend.h
+++ b/cpdb/cpdb-frontend.h
@@ -403,7 +403,7 @@ int cpdbPrintFD(cpdb_printer_obj_t *p, char **jobid, const char *title, char **s
 
 char *cpdbPrintSocket(cpdb_printer_obj_t *p, char **jobid, const char *title);
 
-bool cpdbRefreshPrinterList(cpdb_frontend_obj_t *f, char *backend);
+bool cpdbRefreshPrinterList(cpdb_frontend_obj_t *f, const char *backend);
 
 void cpdbPrinterCallback(cpdb_frontend_obj_t *f, cpdb_printer_obj_t *p, cpdb_printer_update_t change);
 


### PR DESCRIPTION
Use `const char*` instead of `char*` for the `backend` param of `cpdbRefreshPrinterList`. The function was recently added in

    commit 17a1d82d7526c33591879bd97d961405212b408f
    Author: Biswadeep Purkayastha <98874428+metabiswadeep@users.noreply.github.com>
    Date:   Thu Jun 27 19:27:08 2024 +0530

        API functions to refresh printer list and to get D-Bus connection (#35)

        - Added API function cpdbRefreshPrinterList() to refresh the printer list
        - Turned static function get_dbus_connection() into API function cpdbGetDbusConnection()

`const char*` is the usual way to pass C strings.
That also simplifies using the function, see
e.g. comment [1] in one of the changes of a pending change series implementing/updating CPDB support
for the LibreOffice print dialog.

[1] https://gerrit.libreoffice.org/c/core/+/169617/comment/ef77074d_16034f9f/