### PR TITLE
frontend: Drop unused 'own_id' member

### DIFF
--- a/cpdb/cpdb-frontend.c
+++ b/cpdb/cpdb-frontend.c
@@ -38,7 +38,6 @@ cpdb_frontend_obj_t *cpdbGetNewFrontendObj(cpdb_printer_callback printer_cb)
     cpdb_frontend_obj_t *f = g_new0(cpdb_frontend_obj_t, 1);
     
     f->connection = NULL;
-    f->own_id = 0;
     f->printer_cb = printer_cb;
     f->num_backends = 0;
     f->backend = g_hash_table_new_full(g_str_hash,

--- a/cpdb/cpdb-frontend.h
+++ b/cpdb/cpdb-frontend.h
@@ -74,7 +74,6 @@ struct cpdb_frontend_obj_s
 {
     GDBusConnection *connection;
 
-    int own_id;
     cpdb_printer_callback printer_cb;
 
     int num_backends;


### PR DESCRIPTION
Drop `cpdb_frontend_obj_s::own_id`,
since it's effectively unused since

    commit 8f9e0544aa6bd244b79b310f76b2478d407006cc
    Date:   Fri May 31 00:04:43 2024 +0530

        Add new backends while the dialog is open, let frontend not be D-Bus service (#32)