### PR TITLE
Fix a memory leak in cpdbGetSysConfDir

### DIFF
--- a/cpdb/cpdb.c
+++ b/cpdb/cpdb.c
@@ -237,6 +237,7 @@ char *cpdbGetSysConfDir()
     config_dir = cpdbConcatPath(CPDB_SYSCONFDIR, "cpdb");
     if (access(config_dir, R_OK) == 0 || mkdir(config_dir, CPDB_SYSCONFDIR_PERM) == 0)
         return config_dir;
+    g_free(config_dir);
 #endif
 
     if (env_xcd = getenv("XDG_CONFIG_DIRS"))


### PR DESCRIPTION
`cpdbConcatPath` allocates a new string, so
free it if it's not returned.

The value is not used in other code paths,
as `config_dir` is assigned something else.