### PR TITLE
cpdbConcatPath: Actually check XDG_CONFIG_DIRS

### DIFF
--- a/cpdb/cpdb.c
+++ b/cpdb/cpdb.c
@@ -245,7 +245,7 @@ char *cpdbGetSysConfDir()
         path = strtok(env_xcd, ":");
         while (path != NULL)
         {
-            config_dir = cpdbConcatPath(CPDB_SYSCONFDIR, "cpdb");
+            config_dir = cpdbConcatPath(path, "cpdb");
             if (access(config_dir, R_OK) == 0 || mkdir(config_dir, CPDB_SYSCONFDIR_PERM) == 0)
             {
                 free(env_xcd);


### PR DESCRIPTION
Instead of using `CPDB_SYSCONFDIR` again as was
already done above, and doing so in a loop,
use the actual path extracted from the
`XDG_CONFIG_DIRS` environment variable.

That had already been the case earlier, before
it was changed to use `CPDB_SYSCONFDIR`

    commit 20d62e35a1028800fc3b9926e4ac10184815d270
    Date:   Sun Dec 18 00:35:07 2022 +0530

        better debugging & code refactoring

, which at first glance looks like a copy-paste
mistake.