### PR TITLE
Add capability to check CPDB version at runtime

### DIFF
--- a/cpdb/cpdb.c
+++ b/cpdb/cpdb.c
@@ -49,6 +49,10 @@ const char *cpdbGroupTable[][2] = {
 
 static void cpdbDebugLog(CpdbDebugLevel msg_lvl, const char *msg);
 
+const char *cpdbGetVersion()
+{
+    return PACKAGE_VERSION;
+}
 
 void cpdbInit()
 {

--- a/cpdb/cpdb.h
+++ b/cpdb/cpdb.h
@@ -53,6 +53,11 @@ typedef enum {
 } CpdbDebugLevel;
 
 /**
+ * Get CPDB version
+ */
+const char *cpdbGetVersion();
+
+/**
  * Initializes CPDB.
  * It’s the responsibility of the main program to set the locale.
  */

--- a/tools/cpdb-text-frontend.c
+++ b/tools/cpdb-text-frontend.c
@@ -154,6 +154,10 @@ gpointer control_thread(gpointer user_data)
             cpdbDisconnectFromDBus(f);
             cpdbConnectToDBus(f);
         }
+        else if (strcmp(buf, "version") == 0)
+        {
+            printf("CPDB v%s\n", cpdbGetVersion());
+        }
         else if (strcmp(buf, "get-all-printers") == 0)
         {
             cpdbGetAllPrinters(f);


### PR DESCRIPTION
This allows third-party applications to easily manage different CPDB releases.

This is especially important when shipping pre-built binaries of such applications implementing CPDB, as the end users may be running outdated and potentially vulnerable versions of CPDB.