### PR TITLE
text-frontend: Add null check for get-default-printer

### DIFF
--- a/tools/cpdb-text-frontend.c
+++ b/tools/cpdb-text-frontend.c
@@ -372,7 +372,10 @@ gpointer control_thread(gpointer user_data)
              * Eg. "CUPS" or "GCP"
              */
             cpdb_printer_obj_t *p = cpdbGetDefaultPrinterForBackend(f, backend_name);
-            printf("%s\n", p->name);
+            if (p)
+                printf("%s\n", p->name);
+            else
+                printf("No default printer for backend found\n");
         }
         else if (strcmp(buf, "set-user-default-printer") == 0)
         {


### PR DESCRIPTION
Add a null check in handling of the "get-default-printer" command.

Instead of crashing, asking for the default printer for a non-existing backend now prints a message:

    > get-default-printer-for-backend invalid
    [Error] [Frontend] Error getting default printer for backend : GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The name org.openprinting.Backend.invalid was not provided by any .service files
    No default printer for backend found