### PR TITLE
text-frontend: Get locale via GLib

### DIFF
--- a/tools/cpdb-text-frontend.c
+++ b/tools/cpdb-text-frontend.c
@@ -18,7 +18,6 @@ gpointer control_thread(gpointer user_data);
 gpointer background_thread(gpointer user_data);
 
 cpdb_frontend_obj_t *f;
-static const char *locale;
 
 static void printMedia(const cpdb_media_t *media)
 {
@@ -108,8 +107,6 @@ int main(int argc, char **argv)
     setlocale (LC_ALL, "");
     cpdbInit();
 
-    locale = getenv("LANGUAGE");
-
     pid_t pid_temp = getpid();
     char pid[20];
     snprintf(pid, sizeof(pid), "%d", (int)pid_temp);
@@ -134,6 +131,8 @@ gpointer control_thread(gpointer user_data)
 {
     fflush(stdout);
     char buf[BUFSIZE];
+
+    const char *locale = g_get_language_names()[0];
 
     cpdbConnectToDBus(f);
     displayAllPrinters(f);


### PR DESCRIPTION
Instead of only supporting the LANGUAGE environment variable that's not necessarily set, use GLib's `g_get_language_names` to detect the locale to use in the text frontend which takes other environment variables into account as well [1]:

> The returned list is sorted from most desirable to
> least desirable and always contains the default locale “C”.

Also, make `locale` a local variable in the control thread that's the only user instead of using a static variable.

This e.g. makes

    > get-all-translations PDF CUPS

print the translations for the current language in a fresh Ubuntu 23.10 installation where the `LANGUAGE` environment variable is not set, and the result without this commit in place was therefore just

    > get-all-translations PDF CUPS
    No translations found

[1] https://docs.gtk.org/glib/func.get_language_names.html