### PR TITLE
text-frontend: Drop unused local vars

### DIFF
--- a/tools/cpdb-text-frontend.c
+++ b/tools/cpdb-text-frontend.c
@@ -107,11 +107,6 @@ int main(int argc, char **argv)
     setlocale (LC_ALL, "");
     cpdbInit();
 
-    pid_t pid_temp = getpid();
-    char pid[20];
-    snprintf(pid, sizeof(pid), "%d", (int)pid_temp);
-
-    char *dialog_bus_name = malloc(300);
     f = cpdbGetNewFrontendObj(printer_cb);
 
     /** Uncomment the line below if you don't want to use the previously saved settings**/
@@ -122,7 +117,6 @@ int main(int argc, char **argv)
     g_thread_join(thread);
     cpdbStopBackendListRefreshing(f);
     cpdbDeleteFrontendObj(f);
-    free(dialog_bus_name);
 
     return 0;
 }


### PR DESCRIPTION
`dialog_bus_name` is unused since

    commit c990f2ddbd000636e57cf4a8e976e1b2b04648bf
    Date:   Mon Jul 10 14:21:22 2017 +0530

        shift dbus code to FrontendObj

and `pid` is unused since

    commit fb2686ba8f2fc60dc95ae0e2421e386922bf232e
    Date:   Mon Jul 8 21:21:01 2024 +0530

        Removed unused parameter instance_name (#41)

, so drop them, along with the then also unused `pid_temp`.