### PR TITLE
text-frontend: Fix memory leak in "add-setting"

### DIFF
--- a/tools/cpdb-text-frontend.c
+++ b/tools/cpdb-text-frontend.c
@@ -292,7 +292,7 @@ gpointer control_thread(gpointer user_data)
                 continue;
             }
             printf("%s : %s\n", option_name, option_val);
-            cpdbAddSettingToPrinter(p, g_strdup(option_name), g_strdup(option_val));
+            cpdbAddSettingToPrinter(p, option_name, option_val);
         }
         else if (strcmp(buf, "clear-setting") == 0)
         {


### PR DESCRIPTION
The 2 strings allocated with `g_strdup` were never freed. There's no need to duplicate the strings in the first place, so just pass `option_name` and `option_val` as is.