### PR TITLE
Replace cpdbConcat with g_strconcat

### DIFF
--- a/cpdb/cpdb-frontend.c
+++ b/cpdb/cpdb-frontend.c
@@ -698,7 +698,7 @@ cpdb_printer_obj_t *cpdbGetDefaultPrinterForBackend(cpdb_frontend_obj_t *f,
     if (proxy == NULL)
     {
         logwarn("Couldn't find backend proxy for %s\n", backend_name);
-        service_name = cpdbConcat(CPDB_BACKEND_PREFIX, backend_name);
+        service_name = g_strconcat(CPDB_BACKEND_PREFIX, backend_name, NULL);
         proxy = cpdbCreateBackend(f->connection, service_name);
         free(service_name);
         if (proxy == NULL)
@@ -1361,7 +1361,7 @@ cpdb_printer_obj_t *cpdbResurrectPrinterFromFile(const char *filename)
         goto parse_error;
     p->backend_name = g_strdup(strtok(buf, "#"));
     
-    service_name = cpdbConcat(CPDB_BACKEND_PREFIX, p->backend_name);
+    service_name = g_strconcat(CPDB_BACKEND_PREFIX, p->backend_name, NULL);
     if ((connection = cpdbGetDbusConnection()) == NULL)
     {
         logerror("Error resurrecting printer : Couldn't get dbus connection\n");

--- a/cpdb/cpdb.c
+++ b/cpdb/cpdb.c
@@ -79,18 +79,6 @@ gboolean cpdbGetBoolean(const char *g)
     return FALSE;
 }
 
-char *cpdbConcat(const char *s1, const char *s2)
-{
-    if (s1 == NULL)
-        return g_strdup(s2);
-    if (s2 == NULL)
-        return g_strdup(s1);
-
-    char *s = malloc(strlen(s1) + strlen(s2) + 1);
-    sprintf(s, "%s%s", s1, s2);
-    return s;
-}
-
 char *cpdbConcatSep(const char *s1, const char *s2)
 {
     char *s = malloc(strlen(s1) + strlen(s2) + 2);

--- a/cpdb/cpdb.h
+++ b/cpdb/cpdb.h
@@ -74,11 +74,6 @@ char **cpdbNewCStringArray(int num_elems);
 gboolean cpdbGetBoolean(const char *);
 
 /**
- * Concatenate two strings.
- */
-char *cpdbConcat(const char *s1, const char *s2);
-
-/**
  * Concatenate two strings with separator "#".
  */
 char *cpdbConcatSep(const char *s1, const char *s2);


### PR DESCRIPTION
GLib's `g_strconcat` [1] already provides the functionality to concatenate strings, so there's no need to have `cpdbConcat` as a custom implementation and even make that part of the public API.

Therefore, replace the 2 uses of `cpdbConcat` with `g_strconcat` and drop `cpdbConcat`.

[1] https://docs.gtk.org/glib/func.strconcat.html