### PR TITLE
Drop unused cpdbExtractFileName

### DIFF
--- a/cpdb/cpdb.c
+++ b/cpdb/cpdb.c
@@ -198,25 +198,6 @@ char *cpdbGetAbsolutePath(const char *file_path)
     printf("%s\n", fp);
     return fp;
 }
-char *cpdbExtractFileName(const char *file_path)
-{
-    if (!file_path)
-        return NULL;
-
-    char *file_name_ptr = (char *)file_path;
-
-    char *x = (char *)file_path;
-    char c = *x;
-    while (c)
-    {
-        if (c == '/')
-            file_name_ptr = x;
-
-        x++;
-        c = *x;
-    }
-    return file_name_ptr;
-}
 
 char *cpdbGetUserConfDir()
 {

--- a/cpdb/cpdb.h
+++ b/cpdb/cpdb.h
@@ -104,11 +104,6 @@ char *cpdbGetSysConfDir();
 char *cpdbGetAbsolutePath(const char *file_path);
 
 /**
- * Extract file name for path.
- */
-char *cpdbExtractFileName(const char* file_path);
-
-/**
  * Get a group for given option name.
  */
 char *cpdbGetGroup(const char *option_name);


### PR DESCRIPTION
The way that `cpdbExtractFileName` casts a `const char*` to a `char*` and returns a `char*` looks suspicious, as the signature seems to suggest that it would be the caller's responsibility to free the returned string, but it is not actually the owner, as no new string was allocated.

In any case, `cpdbExtractFileName`, or more precisely its predecessor `extract_file_name` is unused
since

    commit cde7d1dcf6fded0ec1147d87eaee5114e78b3c23
    Date:   Thu Aug 24 20:57:57 2017 +0530

        Remove the backend specific parts from original code

and the then already unused function was later renamed to `cpdbExtractFileName` in

    commit b394eaa2369fe105bb4e28222456c0239110070f
    Date:   Sun Aug 14 09:41:25 2022 +0200

        Renamed all API functions, data types and constants

Since the function is neither used here in cpdb-libs nor in cpdb-backend-cups, just drop it altogether.