### PR TITLE
Fix memory leak in cpdbGetDefaultPrinterForBackend

### DIFF
--- a/cpdb/cpdb-frontend.c
+++ b/cpdb/cpdb-frontend.c
@@ -689,7 +689,8 @@ cpdb_printer_obj_t *cpdbFindPrinterObj(cpdb_frontend_obj_t *f,
 cpdb_printer_obj_t *cpdbGetDefaultPrinterForBackend(cpdb_frontend_obj_t *f,
                                                     const char *backend_name)
 {
-    char *def, *service_name;
+    char *def = NULL;
+    char *service_name;
     GError *error = NULL;
     PrintBackend *proxy;
     cpdb_printer_obj_t *p = NULL;
@@ -716,6 +717,7 @@ cpdb_printer_obj_t *cpdbGetDefaultPrinterForBackend(cpdb_frontend_obj_t *f,
     }
     
     p = cpdbFindPrinterObj(f, def, backend_name);
+    g_free(def);
     if (p)
         logdebug("Obtained default printer %s for backend %s\n", p->id, backend_name);
     return p;


### PR DESCRIPTION
As described in [1], `g_variant_get` in
`print_backend_call_get_default_printer_sync` does the following:

> Upon encountering s, o or g, g_variant_get() takes a pointer to a (gchar*)
> (ie: (gchar **)) and sets it to a newly-allocated copy of the
> string. It is appropriate to free this copy using g_free().

Therefore, free the string copy using `g_free` in
`cpdbGetDefaultPrinterForBackend`.

This fixes this memroy leak reported by valgrind:

    ==58581== 4 bytes in 1 blocks are definitely lost in loss record 7 of 1,365
    ==58581==    at 0x4843808: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==58581==    by 0x4915B81: g_malloc (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.0)
    ==58581==    by 0x49324E2: g_strdup (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.0)
    ==58581==    by 0x495AE61: ??? (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.0)
    ==58581==    by 0x495AAEF: ??? (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.0)
    ==58581==    by 0x495BC7D: g_variant_get_va (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.0)
    ==58581==    by 0x495BEF2: g_variant_get (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.0)
    ==58581==    by 0x486FCD3: print_backend_call_get_default_printer_sync (backend-interface.c:3117)
    ==58581==    by 0x485B5BB: cpdbGetDefaultPrinterForBackend (cpdb-frontend.c:711)
    ==58581==    by 0x10B638: control_thread (cpdb-text-frontend.c:367)
    ==58581==    by 0x493F160: ??? (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.0)
    ==58581==    by 0x4A8E731: start_thread (pthread_create.c:447)

[1] https://docs.gtk.org/glib/gvariant-format-strings.html#strings