### PR TITLE
Allow to extract translations from table

### DIFF
--- a/cpdb/cpdb-frontend.c
+++ b/cpdb/cpdb-frontend.c
@@ -1625,6 +1625,85 @@ void cpdbGetAllTranslations(cpdb_printer_obj_t *p,
     p->translations = cpdbUnpackTranslations(translations);
 }
 
+//To be used with cpdbGetAllTranslations only
+char *cpdbGetChoiceTranslationFromTable(cpdb_printer_obj_t *p,
+                               const char *option_name,
+                               const char *choice_name,
+                               const char *locale)
+{
+    char *name_key = NULL;
+    char *choice_key = NULL;
+    char *translation = NULL;
+
+    if (p == NULL || option_name == NULL || choice_name == NULL || locale == NULL)
+    {
+        logwarn("Invalid parameters: cpdbGetChoiceTranslationFromTable()\n");
+        return NULL;
+    }
+
+    if (p->locale != NULL && strcmp(p->locale, locale) == 0)
+    {
+        name_key = cpdbConcatSep(CPDB_OPT_PREFIX, option_name);
+        choice_key = cpdbConcatSep(name_key, choice_name);
+        translation = g_hash_table_lookup(p->translations, choice_key);
+        free(name_key);
+        free(choice_key);
+        if (translation)
+        {
+            logdebug("Found translation=%s; for option=%s;choice=%s;locale=%s;printer=%s#%s;\n",
+                        translation, option_name, choice_name, locale, 
+                        p->id, p->backend_name);
+            return g_strdup(translation);
+        }
+        else
+        {
+            return choice_name;
+        }
+    }
+    else
+    {
+        logwarn("Locale does not exist in table. Use cpdbGetChoiceTranslation instead\n");
+        return NULL;
+    }
+}
+
+//To be used with cpdbGetAllTranslations only
+char *cpdbGetOptionTranslationFromTable(cpdb_printer_obj_t *p,
+                               const char *option_name,
+                               const char *locale)
+{
+    char *name_key = NULL;
+    char *translation = NULL;
+
+    if (p == NULL || option_name == NULL || locale == NULL)
+    {
+        logwarn("Invalid parameters: cpdbGetOptionTranslationFromTable()\n");
+        return NULL;
+    }
+
+    if (p->locale != NULL && strcmp(p->locale, locale) == 0)
+    {
+        name_key = cpdbConcatSep(CPDB_OPT_PREFIX, option_name);
+        translation = g_hash_table_lookup(p->translations, name_key);
+        free(name_key);
+        if (translation)
+        {
+            logdebug("Found translation=%s; for option=%s;locale=%s;printer=%s#%s;\n",
+                        translation, option_name, locale, p->id, p->backend_name);
+            return g_strdup(translation);
+        }
+        else
+        {
+            return option_name;
+        }
+    }
+    else
+    {
+        logwarn("Locale does not exist in table. Use cpdbGetOptionTranslation instead\n");
+        return NULL;
+    }
+}
+
 cpdb_media_t *cpdbGetMedia(cpdb_printer_obj_t *p,
                            const char *media)
 {

--- a/cpdb/cpdb-frontend.c
+++ b/cpdb/cpdb-frontend.c
@@ -1657,7 +1657,7 @@ char *cpdbGetChoiceTranslationFromTable(cpdb_printer_obj_t *p,
         }
         else
         {
-            return choice_name;
+            return g_strdup(choice_name);
         }
     }
     else
@@ -1694,7 +1694,7 @@ char *cpdbGetOptionTranslationFromTable(cpdb_printer_obj_t *p,
         }
         else
         {
-            return option_name;
+            return g_strdup(option_name);
         }
     }
     else

--- a/cpdb/cpdb-frontend.h
+++ b/cpdb/cpdb-frontend.h
@@ -651,6 +651,17 @@ cpdb_printer_obj_t *cpdbResurrectPrinterFromFile(const char *file);
 char *cpdbGetOptionTranslation(cpdb_printer_obj_t *printer_obj, const char *option_name, const char *lang);
 
 /**
+ * Similar to cpdbGetOptionTranslation but onlyy for use with cpdbGetAllTranslations.
+ * 
+ * @param printer_obj       Printer object
+ * @param option_name       Option name
+ * @param lang              BCP47 language tag to be used for translation
+ * 
+ * @return                  Translated name
+ */
+char *cpdbGetOptionTranslationFromTable(cpdb_printer_obj_t *printer_obj, const char *option_name, const char *lang);
+
+/**
  * Get the translation for an option value provided by a printer.
  * 
  * @param printer_obj       Printer object
@@ -661,6 +672,18 @@ char *cpdbGetOptionTranslation(cpdb_printer_obj_t *printer_obj, const char *opti
  * @return                  Translated value
  */
 char *cpdbGetChoiceTranslation(cpdb_printer_obj_t *printer_obj, const char *option_name, const char *choice_name, const char *lang);
+
+/**
+ * Similar to cpdbGetChoiceTranslation but onlyy for use with cpdbGetAllTranslations.
+ * 
+ * @param printer_obj       Printer object
+ * @param option_name       Option name
+ * @param choice_name       Option value
+ * @param lang              BCP47 language tag to be used for translation
+ * 
+ * @return                  Translated value
+ */
+char *cpdbGetChoiceTranslationFromTable(cpdb_printer_obj_t *printer_obj, const char *option_name, const char *choice_name, const char *lang);
 
 /**
  * Get the translation for an option group provided by a printer.


### PR DESCRIPTION
Before, even after using cpdbGetAllTranslations, trying to use cpdbGetOptionTranslation/cpdbGetChoiceTranslation would make dbus calls for those options and choices which did not have translations, which are not necessary and only cause further slowing down of the process of trying to simply use the translations table to get the corresponding translations.