### PR TITLE
Fix memory leak in cpdbCreateBackend

### DIFF
--- a/cpdb/cpdb-frontend.c
+++ b/cpdb/cpdb-frontend.c
@@ -489,21 +489,20 @@ PrintBackend *cpdbCreateBackend(GDBusConnection *connection,
     FILE *file = NULL;
     PrintBackend *proxy;
     GError *error = NULL;
-    char *path, *backend_name;
+    char *path;
     const char *info_dir_name;
     char obj_path[CPDB_BSIZE];
-    
-    backend_name = g_strdup(service_name);
+
     proxy = print_backend_proxy_new_sync(connection,
                                          0,
-                                         backend_name,
+                                         service_name,
                                          CPDB_BACKEND_OBJ_PATH,
                                          NULL,
                                          &error);
     if (error)
     {
         logerror("Error creating backend proxy for %s : %s\n",
-                    backend_name, error->message);
+                    service_name, error->message);
         return NULL;
     }
     return proxy;


### PR DESCRIPTION
The string allocated with `g_strdup` was never freed.

There's no reason to duplicate the string, just use `service_name` directly.

This fixes a memory leak seen e.g. when running
cpdb-text-frontend and printing a file like this:

    print-file /tmp/test.pdf PDF CUPS

Relevant valgrind output:

    ==550231== 30 bytes in 1 blocks are definitely lost in loss record 497 of 1,343
    ==550231==    at 0x4843808: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==550231==    by 0x4916B81: g_malloc (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==550231==    by 0x49334E2: g_strdup (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==550231==    by 0x485ACB5: g_strdup_inline (gstrfuncs.h:321)
    ==550231==    by 0x485ACB5: cpdbCreateBackend (cpdb-frontend.c:496)
    ==550231==    by 0x485A97F: cpdbActivateBackends (cpdb-frontend.c:417)
    ==550231==    by 0x4859FE3: cpdbConnectToDBus (cpdb-frontend.c:230)
    ==550231==    by 0x10A941: control_thread (cpdb-text-frontend.c:131)
    ==550231==    by 0x4940160: ??? (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==550231==    by 0x4A95111: start_thread (pthread_create.c:447)
    ==550231==    by 0x4B1372F: clone (clone.S:100)