### PR TITLE
Fix memory leak in cpdbRefreshPrinterList

### DIFF
--- a/cpdb/cpdb-frontend.c
+++ b/cpdb/cpdb-frontend.c
@@ -327,7 +327,6 @@ bool cpdbRefreshPrinterList(cpdb_frontend_obj_t *f, const char *backend)
         // Compare the backend_name with the provided one 
         if (strcmp(backend_name, backend) == 0) { 
             // Check if backend_name is not in the printers hashtable 
-            char *printer_name = cpdbConcatSep(printer_obj->id, backend_name); 
             g_variant_iter_init(&iter, printers); 
             int printer_exists = 0;
             while (g_variant_iter_loop(&iter, "(v)", &printer)) 


### PR DESCRIPTION
`printer_name` was never freed.

The newly allocated string is never used,
so just drop the variable altogether.

Fixes a memory leak with this valgrind output
seen with LibreOffice WIP CPDB change when printing [1]:

    ==546760== 42 bytes in 3 blocks are definitely lost in loss record 2,228 of 5,439
    ==546760==    at 0x4843808: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==546760==    by 0x130789EA: cpdbConcatSep (cpdb.c:84)
    ==546760==    by 0x130664D8: cpdbRefreshPrinterList (cpdb-frontend.c:330)
    ==546760==    by 0xDFAFAC5: psp::CPDManager::endSpool(rtl::OUString const&, rtl::OUString const&, _IO_FILE*, psp::JobData const&, bool, rtl::OUString const&) (cpdmgr.cxx:626)
    ==546760==    by 0xE0AD11E: PspSalPrinter::StartJob(rtl::OUString const*, rtl::OUString const&, rtl::OUString const&, ImplJobSetup*, vcl::PrinterController&) (genprnpsp.cxx:991)
    ==546760==    by 0xD9D7352: Printer::StartJob(rtl::OUString const&, std::shared_ptr<vcl::PrinterController> const&) (print3.cxx:639)
    ==546760==    by 0xD9D6EC5: Printer::ExecutePrintJob(std::shared_ptr<vcl::PrinterController> const&) (print3.cxx:554)
    ==546760==    by 0xD9D3AEA: Printer::ImplPrintJob(std::shared_ptr<vcl::PrinterController> const&, JobSetup const&) (print3.cxx:569)
    ==546760==    by 0xD9E0F63: (anonymous namespace)::PrintJobAsync::ExecJob(void*) (print3.cxx:318)
    ==546760==    by 0xD9D3BDC: (anonymous namespace)::PrintJobAsync::LinkStubExecJob(void*, void*) (print3.cxx:316)
    ==546760==    by 0xD479700: Link<void*, void>::Call(void*) const (link.hxx:111)
    ==546760==    by 0xD475870: ImplHandleUserEvent(ImplSVEvent*) (winproc.cxx:2285)

[1] https://gerrit.libreoffice.org/c/core/+/169617/30