### PR TITLE
text-frontend: Fix memory leak in "print-file"

### DIFF
--- a/tools/cpdb-text-frontend.c
+++ b/tools/cpdb-text-frontend.c
@@ -420,7 +420,9 @@ gpointer control_thread(gpointer user_data)
                 continue;
             }
             cpdbAddSettingToPrinter(p, "copies", "3");
-            cpdbPrintFile(p, file_path);
+            char* job_id = cpdbPrintFile(p, file_path);
+            g_free(job_id);
+
         }
         else if (strcmp(buf, "pickle-printer") == 0)
         {


### PR DESCRIPTION
Add a local variable for the job ID returned as a
newly allocated string and free it.

Fixes this memory leak shown by valgrind:

    ==127622== 43 bytes in 2 blocks are definitely lost in loss record 754 of 1,370
    ==127622==    at 0x4843808: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==127622==    by 0x4916B81: g_malloc (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==127622==    by 0x49334E2: g_strdup (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==127622==    by 0x495BE61: ??? (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==127622==    by 0x495BAEF: ??? (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==127622==    by 0x495CC7D: g_variant_get_va (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==127622==    by 0x495CEF2: g_variant_get (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==127622==    by 0x4870BA5: print_backend_call_print_socket_sync (backend-interface.c:4038)
    ==127622==    by 0x485CAC4: cpdbPrintSocket (cpdb-frontend.c:1217)
    ==127622==    by 0x485C871: cpdbPrintFD (cpdb-frontend.c:1182)
    ==127622==    by 0x485C63E: cpdbPrintFileWithJobTitle (cpdb-frontend.c:1143)
    ==127622==    by 0x485C5EE: cpdbPrintFile (cpdb-frontend.c:1135)