### PR TITLE
Unref GVariantBuilder to fix memory leak

### DIFF
--- a/cpdb/cpdb-frontend.c
+++ b/cpdb/cpdb-frontend.c
@@ -1976,6 +1976,7 @@ GVariant *cpdbSerializeToGVariant(cpdb_settings_t *s)
         g_variant_builder_add(builder, "(ss)", "NA", "NA");
 
     variant = g_variant_new("a(ss)", builder);
+    g_variant_builder_unref(builder);
     return variant;
 }
 


### PR DESCRIPTION
As the `g_variant_builder_new` doc [1] says:

> You should call `g_variant_builder_unref()` on the return value when
> it is no longer needed. The memory will not be automatically freed by
> any other call.

This fixes a memory leak in `cpdbSerializeToGVariant`.

Corresponding valgrind output without this commit in place when printing a file using cpdb-text-frontend:

    ==127622== 144 bytes in 1 blocks are definitely lost in loss record 1,262 of 1,370
    ==127622==    at 0x4843808: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==127622==    by 0x4916B81: g_malloc (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==127622==    by 0x495A376: g_variant_builder_new (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==127622==    by 0x485E909: cpdbSerializeToGVariant (cpdb-frontend.c:1963)
    ==127622==    by 0x485CA85: cpdbPrintSocket (cpdb-frontend.c:1217)
    ==127622==    by 0x485C871: cpdbPrintFD (cpdb-frontend.c:1182)
    ==127622==    by 0x485C63E: cpdbPrintFileWithJobTitle (cpdb-frontend.c:1143)
    ==127622==    by 0x485C5EE: cpdbPrintFile (cpdb-frontend.c:1135)
    ==127622==    by 0x10B8B7: control_thread (cpdb-text-frontend.c:423)
    ==127622==    by 0x4940160: ??? (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==127622==    by 0x4A95111: start_thread (pthread_create.c:447)
    ==127622==    by 0x4B1372F: clone (clone.S:100)

[1] https://docs.gtk.org/glib/ctor.VariantBuilder.new.html