### PR TITLE
Fix memory leak in cpdbActivateBackends

### DIFF
--- a/cpdb/cpdb-frontend.c
+++ b/cpdb/cpdb-frontend.c
@@ -427,6 +427,7 @@ void cpdbActivateBackends(cpdb_frontend_obj_t *f) {
                 g_hash_table_remove(existing_backends, backend_suffix);
                 g_free(backend_suffix);
             }
+            g_free(service_name);
         }
 
         g_variant_unref(service_names);


### PR DESCRIPTION
The string needs to be freed, see the example in
the `g_variant_iter_next` doc [1].

Fixes a memory leak.
Corresponding valgrind output when printing a file using cpdb-text-frontend:

    ==164170== 4,751 bytes in 231 blocks are definitely lost in loss record 1,338 of 1,339
    ==164170==    at 0x4843808: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==164170==    by 0x4916B81: g_malloc (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==164170==    by 0x49334E2: g_strdup (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==164170==    by 0x495BE61: ??? (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==164170==    by 0x495D240: g_variant_iter_next (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==164170==    by 0x485AA3E: cpdbActivateBackends (cpdb-frontend.c:412)
    ==164170==    by 0x485AB9E: background_thread (cpdb-frontend.c:458)
    ==164170==    by 0x4940160: ??? (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==164170==    by 0x4A95111: start_thread (pthread_create.c:447)
    ==164170==    by 0x4B1372F: clone (clone.S:100)

[1] https://docs.gtk.org/glib/method.VariantIter.next.html