### PR TITLE
Log and free GError in call to "doListing"

### DIFF
--- a/cpdb/cpdb-frontend.c
+++ b/cpdb/cpdb-frontend.c
@@ -237,6 +237,10 @@ void stopListingLookup(gpointer key, gpointer value, gpointer user_data){
     PrintBackend *proxy = value;
     GError *error = NULL; 
     print_backend_call_do_listing_sync(proxy, false, NULL, &error);
+    if (error) {
+        logerror("Error in DBus call doListing: %s\n", error->message);
+        g_error_free(error);
+    }
 }
 
 void cpdbDisconnectFromDBus(cpdb_frontend_obj_t *f)


### PR DESCRIPTION
If an error occurs when calling
`print_backend_call_do_listing_sync`, log the error, and free the memory.

When printing a file using cpdb-text-frontend using

    > print-file /tmp/test.pdf PDF CUPS

and then exiting, this now logs the following error in my setup:

    Error: GDBus.Error:org.freedesktop.DBus.Error.UnknownMethod: Method doListing is not implemented on interface org.openprinting.PrintBackend

This also fixes this memory leak seen
previously, as reported by valgrind:

    ==167205== 149 (16 direct, 133 indirect) bytes in 1 blocks are definitely lost in loss record 1,254 of 1,342
    ==167205==    at 0x4843808: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==167205==    by 0x4916B81: g_malloc (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==167205==    by 0x4931C5C: g_slice_alloc0 (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==167205==    by 0x48F597B: ??? (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==167205==    by 0x48F5DCD: g_error_new_valist (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==167205==    by 0x48F5F0B: g_error_new (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==167205==    by 0x4D0840D: g_dbus_error_new_for_dbus_error (in /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.8200.1)
    ==167205==    by 0x4D08917: g_dbus_error_set_dbus_error (in /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.8200.1)
    ==167205==    by 0x4D19905: g_dbus_message_to_gerror (in /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.8200.1)
    ==167205==    by 0x4D09BCA: ??? (in /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.8200.1)
    ==167205==    by 0x4D11230: ??? (in /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.8200.1)
    ==167205==    by 0x4D1F43D: ??? (in /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.8200.1)
    ==167205==    by 0x4D208A7: g_dbus_proxy_call_sync (in /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.8200.1)
    ==167205==    by 0x48712B5: print_backend_call_do_listing_sync (backend-interface.c:4422)
    ==167205==    by 0x485A047: stopListingLookup (cpdb-frontend.c:239)
    ==167205==    by 0x48FBCD2: g_hash_table_foreach (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==167205==    by 0x485A0B2: cpdbDisconnectFromDBus (cpdb-frontend.c:249)
    ==167205==    by 0x4859AA2: cpdbDeleteFrontendObj (cpdb-frontend.c:62)
    ==167205==    by 0x10A90E: main (cpdb-text-frontend.c:119)

Fixing the actual root cause for the underling error that gets triggered is not covered by this commit, but would have to be analyzed separately.