### PR TITLE
Fix potential double-free in cpdbResurrectPrinterFromFile

### DIFF
--- a/cpdb/cpdb-frontend.c
+++ b/cpdb/cpdb-frontend.c
@@ -1436,7 +1436,6 @@ cpdb_printer_obj_t *cpdbResurrectPrinterFromFile(const char *filename)
 
     fclose(fp);
     free(path);
-    free(service_name);
     free(previous_parent_dialog);
     return p;
 


### PR DESCRIPTION
`service_name` already gets freed further up in the function and is never assigned a new value after this, so trying to free it again is problematic.

This fixes this GCC 14 `-Werror=use-after-free` warning in a `-Wall -Werror` build:

    cpdb-frontend.c:1439:5: error: pointer 'service_name' may be used after 'free' [-Werror=use-after-free]
     1439 |     free(service_name);
          |     ^~~~~~~~~~~~~~~~~~
    cpdb-frontend.c:1383:5: note: call to 'free' here
     1383 |     free(service_name);
          |     ^~~~~~~~~~~~~~~~~~
    cc1: all warnings being treated as errors