### PR TITLE
Return something in non-void function

### DIFF
--- a/cpdb/cpdb-frontend.c
+++ b/cpdb/cpdb-frontend.c
@@ -462,6 +462,7 @@ gpointer background_thread(gpointer user_data) {
         if (f->stop_flag) break;
         cpdbActivateBackends(f);
     }
+    return NULL;
 }
 
 // Start the background thread


### PR DESCRIPTION
Return NULL in `background_thread`, as
the return type is `gpointer`.

Fixes this error in a `-Wall -Werror` build:

    cpdb-frontend.c: In function 'background_thread':
    cpdb-frontend.c:465:1: error: control reaches end of non-void function [-Werror=return-type]
      465 | }
          | ^