### PR TITLE
Delete printer objects when deleting hash table

### DIFF
--- a/cpdb/cpdb-frontend.c
+++ b/cpdb/cpdb-frontend.c
@@ -33,6 +33,11 @@ ________________________________________________ cpdb_frontend_obj_t ___________
 
 **/
 
+static void free_printer_object(void* printer)
+{
+    cpdbDeletePrinterObj(printer);
+}
+
 cpdb_frontend_obj_t *cpdbGetNewFrontendObj(cpdb_printer_callback printer_cb)
 {
     cpdb_frontend_obj_t *f = g_new0(cpdb_frontend_obj_t, 1);
@@ -48,7 +53,7 @@ cpdb_frontend_obj_t *cpdbGetNewFrontendObj(cpdb_printer_callback printer_cb)
     f->printer = g_hash_table_new_full(g_str_hash,
                                        g_str_equal,
                                        free,
-                                       g_free);
+                                       free_printer_object);
     f->last_saved_settings = cpdbReadSettingsFromDisk();
     return f;
 }


### PR DESCRIPTION
Make sure the memory of the printer objects get
freed when the `cpdb_frontend_obj_s::printer`
`GHashTable` is destroyed, by passing a function
that calls `cpdbDeletePrinterObj` as the
function to free the memory allocated for each
value, as the values are `cpdb_printer_obj_t`
objects.

Therefore, just calling `g_free` isn't sufficient.

This fixes a memory leak as reported e.g.
by valgrind when just starting and stopping
cpdb-text-frontend with the CUPS backend
available.

Corresponding valgrind output reporting the
memory leak without this commit in place:

    ==231295== 624 (48 direct, 576 indirect) bytes in 3 blocks are definitely lost in loss record 1,307 of 1,323
    ==231295==    at 0x48489F3: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==231295==    by 0x4916BD9: g_malloc0 (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==231295==    by 0x485E773: cpdbGetNewSettings (cpdb-frontend.c:1908)
    ==231295==    by 0x485BE0C: cpdbGetNewPrinterObj (cpdb-frontend.c:930)
    ==231295==    by 0x485A279: fetchPrinterListFromBackend (cpdb-frontend.c:284)
    ==231295==    by 0x485AA36: cpdbActivateBackends (cpdb-frontend.c:427)
    ==231295==    by 0x485A004: cpdbConnectToDBus (cpdb-frontend.c:232)
    ==231295==    by 0x10A951: control_thread (cpdb-text-frontend.c:131)
    ==231295==    by 0x4940160: ??? (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==231295==    by 0x4A95111: start_thread (pthread_create.c:447)
    ==231295==    by 0x4B1372F: clone (clone.S:100)