### PR TITLE
Free printer object string members in cpdbDeletePrinterObj

### DIFF
--- a/cpdb/cpdb-frontend.c
+++ b/cpdb/cpdb-frontend.c
@@ -947,8 +947,15 @@ void cpdbDeletePrinterObj(cpdb_printer_obj_t *p)
         return;
     
     logdebug("Deleting printer object %s\n", p->id);
-    if (p->backend_name)
-        free(p->backend_name);
+
+    g_free(p->backend_name);
+    g_free(p->id);
+    g_free(p->name);
+    g_free(p->location);
+    g_free(p->info);
+    g_free(p->state);
+    g_free(p->make_and_model);
+
     if (p->backend_proxy)
         g_object_unref(p->backend_proxy);
     if (p->options)


### PR DESCRIPTION
Free the memory allocated for more of the
`cpdb_printer_obj_t` string members.

While at it, also use `g_free` for the `backend_name` member, which removes the need to do a NULL check
manually, as `g_free` (other than plain `free`)
handles NULL just fine. [1]

This fixes a memory leak seen e.g. when running
cpdb-text-frontend (and the CUPS CPDB backend
available) even with the previous commit from
pull request [2] in place that causes `cpdbDeletePrinterObj` to be called for each printer object.
(Without [2], the memory leak is not fixed, as
`cpdbDeletePrinterObj` never gets called when
the hash table is destroyed in the first place.)

Corresponding valgrind output with [2] but not this commit in place:

    ==232997== 237 bytes in 18 blocks are definitely lost in loss record 1,217 of 1,273
    ==232997==    at 0x4843808: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==232997==    by 0x4916B81: g_malloc (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==232997==    by 0x49334E2: g_strdup (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==232997==    by 0x495BE61: ??? (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==232997==    by 0x495BAEF: ??? (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==232997==    by 0x495CC7D: g_variant_get_va (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==232997==    by 0x495CEF2: g_variant_get (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==232997==    by 0x485BFC7: cpdbFillBasicOptions (cpdb-frontend.c:971)
    ==232997==    by 0x485A2AE: fetchPrinterListFromBackend (cpdb-frontend.c:290)
    ==232997==    by 0x485AA51: cpdbActivateBackends (cpdb-frontend.c:432)
    ==232997==    by 0x485A01F: cpdbConnectToDBus (cpdb-frontend.c:237)
    ==232997==    by 0x10A951: control_thread (cpdb-text-frontend.c:131)

[1] https://docs.gtk.org/glib/func.free.html
[2] https://github.com/OpenPrinting/cpdb-libs/pull/71