### PR TITLE
Drop unused cpdb_job_t and cpdbUnpackJobArray

### DIFF
--- a/cpdb/cpdb-frontend.c
+++ b/cpdb/cpdb-frontend.c
@@ -19,10 +19,6 @@ static void                 cpdbUnpackOptions               (int                
                                                              int                        num_media,
                                                              GVariant *                 media_var,
                                                              cpdb_options_t *           options);
-static void                 cpdbUnpackJobArray              (GVariant *                 var,
-                                                             int                        num_jobs,
-                                                             cpdb_job_t *               jobs,
-                                                             char *                     backend_name);
 static GHashTable *         cpdbUnpackTranslations          (GVariant *                 translations);
 static void                 add_to_hash_table               (gpointer                   key,
                                                              gpointer                   value, 
@@ -2158,48 +2154,6 @@ void cpdbDeleteMedia(cpdb_media_t *media)
     free(media);
 }
 
-/**
- * ________________________________ cpdb_job_t __________________________
- */
-void cpdbUnpackJobArray(GVariant *var,
-                        int num_jobs,
-                        cpdb_job_t *jobs,
-                        char *backend_name)
-{
-    int i;
-    GVariantIter *iter;
-    g_variant_get(var, CPDB_JOB_ARRAY_ARGS, &iter);
-    int size;
-    char *jobid, *title, *printer, *user, *state, *submit_time;
-    for (i = 0; i < num_jobs; i++)
-    {
-        g_variant_iter_loop(iter,
-                            CPDB_JOB_ARGS,
-                            &jobid,
-                            &title,
-                            &printer,
-                            &user,
-                            &state,
-                            &submit_time,
-                            &size);
-        logdebug("jobid=%s;\n", jobid);
-        jobs[i].job_id = g_strdup(jobid);
-        logdebug("title=%s;\n", title);
-        jobs[i].title = g_strdup(title);
-        logdebug("printer=%s;\n", printer);
-        jobs[i].printer_id = g_strdup(printer);
-        logdebug("backend_name=%s;\n", backend_name);
-        jobs[i].backend_name = backend_name;
-        logdebug("user=%s;\n", user);
-        jobs[i].user = g_strdup(user);
-        logdebug("state=%s;\n", state);
-        jobs[i].state = g_strdup(state);
-        logdebug("submit_time=%s;\n", submit_time);
-        jobs[i].submitted_at = g_strdup(submit_time);
-        logdebug("size=%d;\n", size);
-        jobs[i].size = size;
-    }
-}
 /**
  * ________________________________utility functions__________________________
  */

--- a/cpdb/cpdb-frontend.h
+++ b/cpdb/cpdb-frontend.h
@@ -37,7 +37,6 @@ typedef struct cpdb_options_s cpdb_options_t;
 typedef struct cpdb_option_s cpdb_option_t;
 typedef struct cpdb_margin_s cpdb_margin_t;
 typedef struct cpdb_media_s cpdb_media_t;
-typedef struct cpdb_job_s cpdb_job_t;
 
 typedef enum cpdb_printer_update_e {
     CPDB_CHANGE_PRINTER_ADDED,
@@ -924,23 +923,6 @@ struct cpdb_media_s
  * @param media             Media-size object
  */
 void cpdbDeleteMedia(cpdb_media_t *media);
-
-/************************************************************************************************/
-/**
-______________________________________ cpdb_job_t __________________________________________
-
-**/
-struct cpdb_job_s
-{
-    char *job_id;
-    char *title;
-    char *printer_id;
-    char *backend_name;
-    char *user;
-    char *state;
-    char *submitted_at;
-    int size;
-};
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Drop this, as it is unused since

    commit 85447e866863ebc7327a32f16e86cba6f487bed3
    Date:   Sat Mar 16 20:49:05 2024 +0530

        Stream print data through a Unix domain socket (#30)

        To ease making a Snap from the CPDB backend for CUPS (and
        other CPDB backends in the future) we now transfer the print
        job data from the dialog to the backend via a Unix domain socket
        and not by dropping the data into a file.

        In addition, we have done also the following changes:
        - Removed support for the "FILE" CPDB backend.
        - Removed API functions cpdbGetAllJobs(),
          cpdbGetActiveJobsCount(), cpdbCancelJob(), and
          cpdbPrintFilePath() and the corresponding D-Bus
          methods.
        - Removed the appropriate commands, "get-all-jobs",
          "get-active-jobs-count", and "cancel-job" from the
          "cpdb-text-frontend" utility.