### PR TITLE
Free option values in cpdbDeleteOption

### DIFF
--- a/cpdb/cpdb-frontend.c
+++ b/cpdb/cpdb-frontend.c
@@ -2136,7 +2136,11 @@ void cpdbDeleteOption(cpdb_option_t *opt)
     if (opt->group_name)
         free(opt->group_name);
     if (opt->supported_values)
+    {
+        for (int i = 0; i < opt->num_supported; i++)
+            free(opt->supported_values[i]);
         free(opt->supported_values);
+    }
     if (opt->default_value)
         free(opt->default_value);
 


### PR DESCRIPTION
Free strings of the single option values
in the array before freeing the array itself.

Fixes a memory leak seen e.g. when running
cpdb-text-frontend and printing the options
of the CUPS-PDF printer using the

    > get-all-options PDF CUPS

command. Corresponding valgrind output:

    ==286266== 1,761 bytes in 146 blocks are definitely lost in loss record 1,274 of 1,297
    ==286266==    at 0x4843808: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==286266==    by 0x4916B81: g_malloc (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==286266==    by 0x49334E2: g_strdup (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==286266==    by 0x485F600: g_strdup_inline (gstrfuncs.h:321)
    ==286266==    by 0x485F600: cpdbUnpackOptions (cpdb-frontend.c:2258)
    ==286266==    by 0x485C455: cpdbGetAllOptions (cpdb-frontend.c:1077)
    ==286266==    by 0x10ACED: control_thread (cpdb-text-frontend.c:197)
    ==286266==    by 0x4940160: ??? (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==286266==    by 0x4A95111: start_thread (pthread_create.c:447)
    ==286266==    by 0x4B1372F: clone (clone.S:100)