### PR TITLE
Fix memory leak in getAllPrintersLookup

### DIFF
--- a/cpdb/cpdb-frontend.c
+++ b/cpdb/cpdb-frontend.c
@@ -602,6 +602,7 @@ void getAllPrintersLookup(gpointer key, gpointer value, gpointer user_data){
         p = cpdbGetNewPrinterObj();
         cpdbFillBasicOptions(p, printer);
         cpdbPrintBasicOptions(p);
+        cpdbDeletePrinterObj(p);
     }
 }
 


### PR DESCRIPTION
Free the printer object created with
`cpdbGetNewPrinterObj` again.

Fixes a memory leak seen e.g. when using
the

    > get-all-printers

command in cpdb-text-frontend.

Corresponding valgrind output:

    ==290968== 1,188 (312 direct, 876 indirect) bytes in 3 blocks are definitely lost in loss record 1,268 of 1,278
    ==290968==    at 0x48489F3: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==290968==    by 0x4916BD9: g_malloc0 (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==290968==    by 0x485BDF7: cpdbGetNewPrinterObj (cpdb-frontend.c:929)
    ==290968==    by 0x485B192: getAllPrintersLookup (cpdb-frontend.c:602)
    ==290968==    by 0x48FBCD2: g_hash_table_foreach (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==290968==    by 0x485B227: cpdbGetAllPrinters (cpdb-frontend.c:611)
    ==290968==    by 0x10AABC: control_thread (cpdb-text-frontend.c:156)
    ==290968==    by 0x4940160: ??? (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==290968==    by 0x4A95111: start_thread (pthread_create.c:447)
    ==290968==    by 0x4B1372F: clone (clone.S:100)