### PR TITLE
text-frontend: Fix memleaks in "get-option-translation" etc.

### DIFF
--- a/tools/cpdb-text-frontend.c
+++ b/tools/cpdb-text-frontend.c
@@ -449,7 +449,9 @@ gpointer control_thread(gpointer user_data)
                 puts(MESSAGE_PRINTER_NOT_FOUND);
                 continue;
             }
-            printf("%s\n", cpdbGetOptionTranslation(p, option_name, locale));
+            char* translation = cpdbGetOptionTranslation(p, option_name, locale);
+            printf("%s\n", translation);
+            g_free(translation);
         }
         else if (strcmp(buf, "get-choice-translation") == 0)
         {
@@ -464,7 +466,9 @@ gpointer control_thread(gpointer user_data)
                 puts(MESSAGE_PRINTER_NOT_FOUND);
                 continue;
             }
-            printf("%s\n", cpdbGetChoiceTranslation(p, option_name, choice_name, locale));
+            char* translation = cpdbGetChoiceTranslation(p, option_name, choice_name, locale);
+            printf("%s\n", translation);
+            g_free(translation);
         }
         else if (strcmp(buf, "get-group-translation") == 0)
         {
@@ -478,7 +482,9 @@ gpointer control_thread(gpointer user_data)
                 puts(MESSAGE_PRINTER_NOT_FOUND);
                 continue;
             }
-            printf("%s\n", cpdbGetGroupTranslation(p, group_name, locale));
+            char* translation = cpdbGetGroupTranslation(p, group_name, locale);
+            printf("%s\n", translation);
+            g_free(translation);
         }
         else if (strcmp(buf, "get-all-translations") == 0)
         {


### PR DESCRIPTION
Assign the newly allocated string to a local variable and free it after printing it.

This fixes memory leaks seen with cpdb-text-frontend when using commands like these ones to print translation for options of the CUPS-PDF printer:

    > get-option-translation output-bin PDF CUPS
    Output Tray
    > get-choice-translation output-bin face-down PDF CUPS
    Face Down

Sample valgrind output:

    ==294129== 12 bytes in 1 blocks are definitely lost in loss record 56 of 1,291
    ==294129==    at 0x4843808: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==294129==    by 0x4916B81: g_malloc (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==294129==    by 0x49334E2: g_strdup (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==294129==    by 0x495BE61: ??? (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==294129==    by 0x495BAEF: ??? (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==294129==    by 0x495CC7D: g_variant_get_va (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==294129==    by 0x495CEF2: g_variant_get (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==294129==    by 0x486FFB3: print_backend_call_get_option_translation_sync (backend-interface.c:3337)
    ==294129==    by 0x485D843: cpdbGetOptionTranslation (cpdb-frontend.c:1486)
    ==294129==    by 0x10BA32: control_thread (cpdb-text-frontend.c:452)
    ==294129==    by 0x4940160: ??? (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==294129==    by 0x4A95111: start_thread (pthread_create.c:447)
    ==294129==    by 0x4B1372F: clone (clone.S:100)