### PR TITLE
Fix memory leaks in cpdbGetOptionTranslation etc.

### DIFF
--- a/cpdb/cpdb-frontend.c
+++ b/cpdb/cpdb-frontend.c
@@ -1500,7 +1500,7 @@ char *cpdbGetOptionTranslation(cpdb_printer_obj_t *p,
     
     logdebug("Obtained translation=%s; for option=%s;locale=%s;printer=%s#%s;\n",
                 translation, option_name, locale, p->id, p->backend_name);
-    return g_strdup(translation);
+    return translation;
 }
 
 char *cpdbGetChoiceTranslation(cpdb_printer_obj_t *p,
@@ -1552,7 +1552,7 @@ char *cpdbGetChoiceTranslation(cpdb_printer_obj_t *p,
     logdebug("Obtained translation=%s; for option=%s;choice=%s;locale=%s;printer=%s#%s;\n",
                 translation, option_name, choice_name, locale, 
                 p->id, p->backend_name);
-    return g_strdup(translation);
+    return translation;
 }
 
 
@@ -1600,7 +1600,7 @@ char *cpdbGetGroupTranslation(cpdb_printer_obj_t *p,
     
     logdebug("Obtained translation=%s; for group=%s;locale=%s;printer=%s#%s;\n",
                 translation, group_name, locale, p->id, p->backend_name);
-    return g_strdup(translation);
+    return translation;
 }
 
 void cpdbGetAllTranslations(cpdb_printer_obj_t *p,


### PR DESCRIPTION
`print_backend_call_get_option_translation_sync` calls `g_variant_get`, which already allocates a new string for `translation`, so there's no need to call `g_strdup` again.

Same for `cpdbGetChoiceTranslation` and `cpdbGetGroupTranslation`.

This fixes memory leaks seen e.g. with cpdb-text-frontend when using commands like these ones to print translation for options of the CUPS-PDF printer:

    > get-option-translation output-bin PDF CUPS
    Output Tray
    > get-choice-translation output-bin face-down PDF CUPS
    Face Down

Corresponding valgrind output:

    ==298753== 12 bytes in 1 blocks are definitely lost in loss record 55 of 1,289
    ==298753==    at 0x4843808: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==298753==    by 0x4916B81: g_malloc (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==298753==    by 0x49334E2: g_strdup (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==298753==    by 0x495BE61: ??? (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==298753==    by 0x495BAEF: ??? (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==298753==    by 0x495CC7D: g_variant_get_va (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==298753==    by 0x495CEF2: g_variant_get (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==298753==    by 0x486FFB3: print_backend_call_get_option_translation_sync (backend-interface.c:3337)
    ==298753==    by 0x485D843: cpdbGetOptionTranslation (cpdb-frontend.c:1486)
    ==298753==    by 0x10BA4D: control_thread (cpdb-text-frontend.c:452)
    ==298753==    by 0x4940160: ??? (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8200.1)
    ==298753==    by 0x4A95111: start_thread (pthread_create.c:447)
    ==298753==    by 0x4B1372F: clone (clone.S:100)