### PR TITLE
frontend: Check file before creating print job

### DIFF
--- a/cpdb/cpdb-frontend.c
+++ b/cpdb/cpdb-frontend.c
@@ -1148,20 +1148,18 @@ char *cpdbPrintFile(cpdb_printer_obj_t *p,
 char *cpdbPrintFileWithJobTitle(cpdb_printer_obj_t *p,
                     const char *file_path, const char *title)
 {
+    FILE *file = fopen(file_path, "r");
+    if (file == NULL) {
+        logerror("Error opening file %s on %s %s: %s\n",
+                 file_path, p->id, p->backend_name, strerror(errno));
+        return NULL;
+    }
+
     char *jobid = NULL;
     char *socket_path = NULL;
     int fd = cpdbPrintFD(p, &jobid, title, &socket_path);
     if (fd == -1) {
         logerror("Error connecting to backend for printing file %s on %s %s: %s\n",
-                 file_path, p->id, p->backend_name, strerror(errno));
-        g_free(socket_path);
-        return NULL;
-    }
-
-    FILE *file = fopen(file_path, "r");
-    if (file == NULL) {
-        close(fd);
-        logerror("Error opening file %s on %s %s: %s\n",
                  file_path, p->id, p->backend_name, strerror(errno));
         g_free(socket_path);
         return NULL;


### PR DESCRIPTION
Try to open the file at the given file path before creating a print job using `cpdbPrintFD`.

Otherwise, passing an invalid path causes a print
job to be created that never gets processed.

For example, with cpdb-text-frontend, passing
an invalid path would print an error message:

    > print-file /dummy/nonexistent PDF CUPS
    [Error] [Frontend] Error opening file /dummy/nonexistent on PDF CUPS: No such file or directory

But it would still create a print job:

    $ lpstat
    PDF-209                 michi                0   2024-11-20T09:01:02 CET

That one would never get finished and has to be manually cancelled using `cancel <jobid>`.

(I noticed this because on KDE Plamsa, the printer widget was showing after that failed attempt, due to the pending print job.)

With this commit in place, the same error message is shown, but no print job is created.