### PR TITLE
Allow NULL for the callback in cpdbGetNewFrontendObj()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,6 @@
 
 ## CHANGES IN V2.0b7 (19th February 2025)
 
-- Allow NULL for the callback in cpdbGetNewFrontendObj()
-  This enhancement allows calling cpdbGetNewFrontendObj(NULL) to use the default
-  callback function cpdbPrinterCallback(), making the API simpler to use.
-
 - Add capability to check CPDB version at runtime
   This allows third-party applications to easily manage different CPDB
   releases. This is especially important when shipping pre-built

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## CHANGES IN V2.0b7 (19th February 2025)
 
+- Allow NULL for the callback in cpdbGetNewFrontendObj()
+  This enhancement allows calling cpdbGetNewFrontendObj(NULL) to use the default
+  callback function cpdbPrinterCallback(), making the API simpler to use.
+
 - Add capability to check CPDB version at runtime
   This allows third-party applications to easily manage different CPDB
   releases. This is especially important when shipping pre-built

--- a/cpdb/cpdb-frontend.c
+++ b/cpdb/cpdb-frontend.c
@@ -39,7 +39,7 @@ cpdb_frontend_obj_t *cpdbGetNewFrontendObj(cpdb_printer_callback printer_cb)
     cpdb_frontend_obj_t *f = g_new0(cpdb_frontend_obj_t, 1);
     
     f->connection = NULL;
-    f->printer_cb = printer_cb;
+    f->printer_cb = printer_cb ? printer_cb : cpdbPrinterCallback;
     f->num_backends = 0;
     f->backend = g_hash_table_new_full(g_str_hash,
                                        g_str_equal,

--- a/cpdb/cpdb-frontend.h
+++ b/cpdb/cpdb-frontend.h
@@ -91,11 +91,20 @@ struct cpdb_frontend_obj_s
 };
 
 /**
+ * Default callback function for printer updates.
+ * Logs printer updates to the console.
+ * 
+ * @param frontend_obj      Frontend instance
+ * @param printer_obj       Printer object updated
+ * @param update            Type of update
+ */
+void cpdbPrinterCallback(cpdb_frontend_obj_t *frontend_obj, cpdb_printer_obj_t *printer_obj, cpdb_printer_update_t update);
+
+/**
  * Get a new cpdb_frontend_obj_t instance.
  * 
- * @param instance_name     Unique name for the frontend object, can be NULL
- * @param printer_cb        Callback function for any printer updates
- * @param change            Type of update
+ * @param printer_cb        Callback function for any printer updates.
+ *                          If NULL is passed, the default cpdbPrinterCallback function will be used.
  * 
  * @return                  Frontend instance
  */

--- a/tools/cpdb-text-frontend.c
+++ b/tools/cpdb-text-frontend.c
@@ -102,12 +102,11 @@ static void acquire_translations_callback(cpdb_printer_obj_t *p, int success, vo
 
 int main(int argc, char **argv)
 {
-    cpdb_printer_callback printer_cb = (cpdb_printer_callback)cpdbPrinterCallback;
-
     setlocale (LC_ALL, "");
     cpdbInit();
 
-    f = cpdbGetNewFrontendObj(printer_cb);
+    // Using the default callback by passing NULL
+    f = cpdbGetNewFrontendObj(NULL);
 
     /** Uncomment the line below if you don't want to use the previously saved settings**/
     cpdbIgnoreLastSavedSettings(f);


### PR DESCRIPTION
@tillkamppeter 
### Description
This pull request enhances the cpdbGetNewFrontendObj() function to accept NULL for the callback parameter. When NULL is passed, the function will use the default cpdbPrinterCallback() function, which logs printer updates to the console. This makes the API simpler to use for applications that don't need custom printer update handling.

### Changes
* Modified cpdbGetNewFrontendObj() in cpdb-frontend.c to use the default callback when NULL is passed
* Added a declaration for cpdbPrinterCallback() in cpdb-frontend.h to make it accessible to users
* Updated documentation in cpdb-frontend.h to reflect this change
* Updated the example in cpdb-text-frontend.c to demonstrate using NULL for the callback
* Updated CHANGES.md to document this enhancement

**Fixes #80 - Allow NULL for the callback in cpdbGetNewFrontendObj()**
