### PR TITLE
Fix Memory Management for Printer Objects in CPDB API

### DIFF
--- a/cpdb/cpdb-frontend.c
+++ b/cpdb/cpdb-frontend.c
@@ -83,7 +83,6 @@ void cpdbPrinterCallback(cpdb_frontend_obj_t *f, cpdb_printer_obj_t *p, cpdb_pri
 
     case CPDB_CHANGE_PRINTER_REMOVED:
         g_message("Removed printer %s : %s!\n", p->name, p->backend_name);
-        cpdbDeletePrinterObj(p);
         break;
     
     case CPDB_CHANGE_PRINTER_STATE_CHANGED:
@@ -129,6 +128,7 @@ void cpdbOnPrinterRemoved(GDBusConnection *connection,
     g_variant_get(parameters, "(ss)", &printer_id, &backend_name);
     cpdb_printer_obj_t *p = cpdbRemovePrinter(f, printer_id, backend_name);
     f->printer_cb(f, p, CPDB_CHANGE_PRINTER_REMOVED);
+    cpdbDeletePrinterObj(p);
 }
 
 void cpdbOnPrinterStateChanged(GDBusConnection *connection,


### PR DESCRIPTION
### Description:
This pull request addresses issues related to double freeing and memory leaks in the CPDB library's printer object handling.

## Changes Made:
As suggested by @tillkamppeter in issue itself, I have made the following changes:

* Revised Memory Management: The responsibility for freeing printer objects has been moved from the callback function to the cpdbOnPrinterRemoved() function. This ensures that printer objects are freed immediately after the callback is executed.
* Updated Callback Logic: Removed the printer object freeing from the cpdbPrinterCallback() function to prevent **double-free errors** when custom callbacks are used.

These changes enhance the reliability of the CPDB API and simplify its usage, ensuring developers no longer need to worry about memory management issues.

**Fixes Issue #79 cpdbOnPrinterRemoved(): Free printer object directly, do not expect it from the callback**